### PR TITLE
Updated ilastik version to release candidate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6
 
 RUN pip install scikit-image h5py pandas numpy pathlib tifffile pathlib scipy
 
-ARG ilastik_binary=ilastik-1.4.0b27-Linux.tar.bz2
+ARG ilastik_binary=ilastik-1.4.0rc8-Linux.tar.bz2
 
 ADD http://files.ilastik.org/$ilastik_binary /
 


### PR DESCRIPTION
The last version is not compatible with multicut of the release candidate version 1.4.0rc8.