### PR TITLE
Update ilastik version to 1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6
 
 RUN pip install scikit-image h5py pandas numpy pathlib tifffile pathlib scipy
 
-ARG ilastik_binary=ilastik-1.4.0rc8-Linux.tar.bz2
+ARG ilastik_binary=ilastik-1.4.0-Linux.tar.bz2
 
 ADD http://files.ilastik.org/$ilastik_binary /
 


### PR DESCRIPTION
Ilastik developers just released version 1.4.0 on February 20th 2023. This seems to be the next stable release version and we should thus update our container.